### PR TITLE
Allow for different workspace and resource usernames

### DIFF
--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -26,22 +26,27 @@ jobs:
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |
           source inputs.sh
+          workdir=/home/${resource_username}/pw/jobs/script_submitter/tmp
           echo Making working directory on remote resource...
-          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p /home/${resource_username}/pw/jobs/script_submitter/tmp
+          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p -v ${workdir}
           echo Copying script to working directory...
-          scp script.sh ${{ inputs.resource.ip }}:/home/${resource_username}/pw/jobs/script_submitter/tmp
+          scp -v script.sh ${{ inputs.resource.ip }}:${workdir}/script.sh
+          echo Ensure script is executable...
+          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} chmod u+x -v ${workdir}/script.sh
           echo Done, ready to move to the next step.
       - name: Run Script in Controller Node
         if: ${{ inputs.jobschedulertype === CONTROLLER }}
         run: |
           source inputs.sh
-          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} /home/${resource_username}/pw/jobs/script_submitter/tmp/script.sh
+          workdir=/home/${resource_username}/pw/jobs/script_submitter/tmp
+          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} ${workdir}/script.sh
       - name: Submit Script to SLURM Partition
         if: ${{ inputs.jobschedulertype === SLURM }}
         run: |
           set -x
           source inputs.sh
-          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} sbatch /home/${resource_username}/pw/jobs/script_submitter/tmp/script.sh  | tail -1 | awk -F ' ' '{print $4}')
+          workdir=/home/${resource_username}/pw/jobs/script_submitter/tmp
+          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} sbatch ${workdir}/script.sh  | tail -1 | awk -F ' ' '{print $4}')
           # Check if jobid is empty and exit with error if true
           if [[ -z "${jobid}" ]]; then
               echo "Error: Job submission failed. jobid is empty." >&2
@@ -52,7 +57,8 @@ jobs:
         if: ${{ inputs.jobschedulertype === PBS }}
         run: |
           source inputs.sh
-          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} qsub /home/${resource_username}/pw/script_submitter/tmp/script.sh)
+          workdir=/home/${resource_username}/pw/jobs/script_submitter/tmp
+          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} qsub ${workdir}/script.sh)
           # Check if jobid is empty and exit with error if true
           if [[ -z "${jobid}" ]]; then
               echo "Error: Job submission failed. jobid is empty." >&2

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -13,10 +13,12 @@ jobs:
           echo ~
           echo Remote test
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} echo ~
-          echo "==========What happens if I access my resource?======="
+          echo "==========What resource info is provided by ACTIVATE?======="
           echo ${{ inputs.resource }}
-          echo "==========Can I access inputs.sh?==========="
+          echo "==========What additional info is available in inputs.sh?==========="
+          cat inputs.sh
           source inputs.sh
+          echo Printing just resource information...
           env | grep resource
           echo Printing resource_username...
           echo $resource_username
@@ -24,8 +26,11 @@ jobs:
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |
           source inputs.sh
+          echo Making working directory on remote resource...
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p /home/${resource_username}/pw/jobs/script_submitter/tmp
+          echo Copying script to working directory...
           scp script.sh ${{ inputs.resource.ip }}:/home/${resource_username}/pw/jobs/script_submitter/tmp
+          echo Done, ready to move to the next step.
       - name: Run Script in Controller Node
         if: ${{ inputs.jobschedulertype === CONTROLLER }}
         run: |

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -18,7 +18,16 @@ jobs:
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |
           source inputs.sh
-          workdir=/home/${resource_username}/pw/jobs/script_submitter/tmp
+          echo Set workdir to cluster home matching user workspace launch directory
+          echo User workspace launch directory is ${PWD}
+          # Use bash search and replace with anchor
+          echo Stripping local home prefix from launch directory is ${PWD/#$HOME/}
+          resource_home=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} 'echo $HOME')
+          echo Resource home is $resource_home
+          # Not true on all clusters!
+          #echo Resource home is /home/${resource_username}
+          workdir=${resource_home}${PWD/#$HOME/}
+          echo Final workdir on remote is ${workdir}
           echo Making working directory on remote resource...
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p -v ${workdir}
           echo Copying script to working directory...

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -8,11 +8,15 @@ jobs:
           chmod +x script.sh
       - name: Test workflow launch context
         run: |
-          echo What does tilde do?
+          echo "==========What does tilde do?=========="
           echo Local test
           echo ~
           echo Remote test
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} echo ~
+          echo "==========What is my local env?========"
+          env
+          echo "==========What is my remote env?======="
+          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} env
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -20,12 +20,10 @@ jobs:
           source inputs.sh
           echo Set workdir to cluster home matching user workspace launch directory
           echo User workspace launch directory is ${PWD}
-          # Use bash search and replace with anchor
-          echo Stripping local home prefix from launch directory is ${PWD/#$HOME/}
+          echo Use bash search and replace with anchor to
+          echo remove local home prefix from launch directory with result ${PWD/#$HOME/}
           resource_home=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} 'echo $HOME')
           echo Resource home is $resource_home
-          # Not true on all clusters!
-          #echo Resource home is /home/${resource_username}
           workdir=${resource_home}${PWD/#$HOME/}
           echo Final workdir on remote is ${workdir}
           echo Making working directory on remote resource...

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -12,13 +12,10 @@ jobs:
           pwd
           echo "==========What resource info is provided by ACTIVATE?======="
           echo ${{ inputs.resource }}
-          echo "==========What additional info is available in inputs.sh?==========="
-          cat inputs.sh
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |
-          source inputs.sh
-          echo Set workdir to cluster home matching user workspace launch directory
+          echo Set workdir on cluster home to match user workspace launch directory
           echo User workspace launch directory is ${PWD}
           echo Use bash search and replace with anchor to
           echo remove local home prefix from launch directory with result ${PWD/#$HOME/}
@@ -36,7 +33,6 @@ jobs:
       - name: Run Script in Controller Node
         if: ${{ inputs.jobschedulertype === CONTROLLER }}
         run: |
-          source inputs.sh
           resource_home=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} 'echo $HOME')
           workdir=${resource_home}${PWD/#$HOME/}
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} ${workdir}/script.sh
@@ -44,7 +40,6 @@ jobs:
         if: ${{ inputs.jobschedulertype === SLURM }}
         run: |
           set -x
-          source inputs.sh
           resource_home=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} 'echo $HOME')
           workdir=${resource_home}${PWD/#$HOME/}
           jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} sbatch ${workdir}/script.sh  | tail -1 | awk -F ' ' '{print $4}')
@@ -57,7 +52,6 @@ jobs:
       - name: Submit Script to PBS Queue
         if: ${{ inputs.jobschedulertype === PBS }}
         run: |
-          source inputs.sh
           resource_home=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} 'echo $HOME')
           workdir=${resource_home}${PWD/#$HOME/}
           jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} qsub ${workdir}/script.sh)

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -13,15 +13,13 @@ jobs:
           echo ~
           echo Remote test
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} echo ~
-          echo "==========What is my local env?========"
-          env
-          echo "==========What is my remote env?======="
-          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} env
           echo "==========What happens if I access my resource?======="
           echo ${{ inputs.resource }}
           echo "==========Can I access inputs.sh?==========="
           source inputs.sh
           env | grep resource
+          echo Printing resource_username...
+          echo $resource_username
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -25,16 +25,20 @@ jobs:
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p ~/pw/jobs/script_submitter/tmp
-          scp script.sh ${{ inputs.resource.ip }}:~/pw/jobs/script_submitter/tmp
+          source inputs.sh
+          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p /home/${resource_username}/pw/jobs/script_submitter/tmp
+          scp script.sh ${{ inputs.resource.ip }}:/home/${resource_username}/pw/jobs/script_submitter/tmp
       - name: Run Script in Controller Node
         if: ${{ inputs.jobschedulertype === CONTROLLER }}
-        run: ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} ~/pw/jobs/script_submitter/tmp/script.sh
+        run: |
+          source inputs.sh
+          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} /home/${resource_username}/pw/jobs/script_submitter/tmp/script.sh
       - name: Submit Script to SLURM Partition
         if: ${{ inputs.jobschedulertype === SLURM }}
         run: |
           set -x
-          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} sbatch ~/pw/jobs/script_submitter/tmp/script.sh  | tail -1 | awk -F ' ' '{print $4}')
+          source inputs.sh
+          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} sbatch /home/${resource_username}/pw/jobs/script_submitter/tmp/script.sh  | tail -1 | awk -F ' ' '{print $4}')
           # Check if jobid is empty and exit with error if true
           if [[ -z "${jobid}" ]]; then
               echo "Error: Job submission failed. jobid is empty." >&2
@@ -44,7 +48,8 @@ jobs:
       - name: Submit Script to PBS Queue
         if: ${{ inputs.jobschedulertype === PBS }}
         run: |
-          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} qsub ~/pw/script_submitter/tmp/script.sh)
+          source inputs.sh
+          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} qsub /home/${resource_username}/pw/script_submitter/tmp/script.sh)
           # Check if jobid is empty and exit with error if true
           if [[ -z "${jobid}" ]]; then
               echo "Error: Job submission failed. jobid is empty." >&2

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -19,6 +19,9 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} env
           echo "==========What happens if I access my resource?======="
           echo ${{ inputs.resource }}
+          echo "==========Can I access inputs.sh?==========="
+          source inputs.sh
+          env | grep resource
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -6,6 +6,13 @@ jobs:
         run: |
           echo '${{ inputs.script_text }}' > script.sh
           chmod +x script.sh
+      - name: Test workflow launch context
+        run: |
+          echo What does tilde do?
+          echo Local test
+          echo ~
+          echo Remote test
+          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} echo ~
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -29,7 +29,7 @@ jobs:
           echo Making working directory on remote resource...
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p -v ${workdir}
           echo Copying script to working directory...
-          scp -v script.sh ${{ inputs.resource.ip }}:${workdir}/script.sh
+          scp script.sh ${{ inputs.resource.ip }}:${workdir}/script.sh
           echo Ensure script is executable...
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} chmod u+x -v ${workdir}/script.sh
           echo Done, ready to move to the next step.
@@ -37,14 +37,16 @@ jobs:
         if: ${{ inputs.jobschedulertype === CONTROLLER }}
         run: |
           source inputs.sh
-          workdir=/home/${resource_username}/pw/jobs/script_submitter/tmp
+          resource_home=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} 'echo $HOME')
+          workdir=${resource_home}${PWD/#$HOME/}
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} ${workdir}/script.sh
       - name: Submit Script to SLURM Partition
         if: ${{ inputs.jobschedulertype === SLURM }}
         run: |
           set -x
           source inputs.sh
-          workdir=/home/${resource_username}/pw/jobs/script_submitter/tmp
+          resource_home=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} 'echo $HOME')
+          workdir=${resource_home}${PWD/#$HOME/}
           jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} sbatch ${workdir}/script.sh  | tail -1 | awk -F ' ' '{print $4}')
           # Check if jobid is empty and exit with error if true
           if [[ -z "${jobid}" ]]; then
@@ -56,7 +58,8 @@ jobs:
         if: ${{ inputs.jobschedulertype === PBS }}
         run: |
           source inputs.sh
-          workdir=/home/${resource_username}/pw/jobs/script_submitter/tmp
+          resource_home=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} 'echo $HOME')
+          workdir=${resource_home}${PWD/#$HOME/}
           jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} qsub ${workdir}/script.sh)
           # Check if jobid is empty and exit with error if true
           if [[ -z "${jobid}" ]]; then

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -17,6 +17,8 @@ jobs:
           env
           echo "==========What is my remote env?======="
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} env
+          echo "==========What happens if I access my resource?======="
+          echo ${{ inputs.resource }}
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -9,16 +9,16 @@ jobs:
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p ~/${PWD/#$HOME/}
-          scp script.sh ${{ inputs.resource.ip }}:~/${PWD/#$HOME/}
+          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} mkdir -p ~/pw/jobs/script_submitter/tmp
+          scp script.sh ${{ inputs.resource.ip }}:~/pw/jobs/script_submitter/tmp
       - name: Run Script in Controller Node
         if: ${{ inputs.jobschedulertype === CONTROLLER }}
-        run: ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} ~/${PWD/#$HOME/}/script.sh
+        run: ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} ~/pw/jobs/script_submitter/tmp/script.sh
       - name: Submit Script to SLURM Partition
         if: ${{ inputs.jobschedulertype === SLURM }}
         run: |
           set -x
-          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} sbatch ~/${PWD/#$HOME/}/script.sh  | tail -1 | awk -F ' ' '{print $4}')
+          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} sbatch ~/pw/jobs/script_submitter/tmp/script.sh  | tail -1 | awk -F ' ' '{print $4}')
           # Check if jobid is empty and exit with error if true
           if [[ -z "${jobid}" ]]; then
               echo "Error: Job submission failed. jobid is empty." >&2
@@ -28,7 +28,7 @@ jobs:
       - name: Submit Script to PBS Queue
         if: ${{ inputs.jobschedulertype === PBS }}
         run: |
-          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} qsub ~/${PWD/#$HOME/}/script.sh)
+          jobid=$(ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} qsub ~/pw/script_submitter/tmp/script.sh)
           # Check if jobid is empty and exit with error if true
           if [[ -z "${jobid}" ]]; then
               echo "Error: Job submission failed. jobid is empty." >&2

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -8,22 +8,12 @@ jobs:
           chmod +x script.sh
       - name: Test workflow launch context
         run: |
-          echo "==========What does tilde do?=========="
-          echo Local test
-          echo ~
-          echo Remote test
-          ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} echo ~
           echo "==========Where is the workflow being launched from?========"
           pwd
           echo "==========What resource info is provided by ACTIVATE?======="
           echo ${{ inputs.resource }}
           echo "==========What additional info is available in inputs.sh?==========="
           cat inputs.sh
-          source inputs.sh
-          echo Printing just resource information...
-          env | grep resource
-          echo Printing resource_username...
-          echo $resource_username
       - name: Transfer Script to Cluster
         if: ${{  inputs.input_method === TEXT || inputs.input_method === WORKSPACE_PATH }}
         run: |

--- a/008_script_submitter/workflow.yaml
+++ b/008_script_submitter/workflow.yaml
@@ -13,6 +13,8 @@ jobs:
           echo ~
           echo Remote test
           ssh -o StrictHostKeyChecking=no ${{ inputs.resource.ip }} echo ~
+          echo "==========Where is the workflow being launched from?========"
+          pwd
           echo "==========What resource info is provided by ACTIVATE?======="
           echo ${{ inputs.resource }}
           echo "==========What additional info is available in inputs.sh?==========="


### PR DESCRIPTION
The original script_submitter code used `~/${PWD/#$HOME}` as the working directory for launching scripts on the remote resource. The problem with this is that `~` and `$HOME` in the ssh commands in the job steps are filled in in the *user workspace* (i.e. the usercontainer context) and not in the remote resource context. This means that if your PW user is `pwuser` and your username on the remote is `remoteuser`, usage of `~` and `$HOME` will always result in `/home/pwuser` and not `/home/remoteuser`.

The script was not getting transferred because the paths are not right. To solve this issue, I explicitly find the remote resource's home directory and append it to the PW launch dir which has the PW usercontainer home prefix removed. Also, for some (but not all!) clusters, execution on the head node was not working because the script did not have execute permissions. So I added `chmod u+x` explicitly.